### PR TITLE
Distinguish between user cancelled and permission denied

### DIFF
--- a/rx_paparazzo/src/main/java/com/fuck_boilerplate/rx_paparazzo/RxPaparazzo.java
+++ b/rx_paparazzo/src/main/java/com/fuck_boilerplate/rx_paparazzo/RxPaparazzo.java
@@ -34,6 +34,7 @@ import rx.Observable;
 import rx_activity_result.RxActivityResult;
 
 public final class RxPaparazzo {
+    public static final int RESULT_DENIED_PERMISSION = 2;
 
     public static void register(Application application) {
         RxActivityResult.register(application);

--- a/rx_paparazzo/src/main/java/com/fuck_boilerplate/rx_paparazzo/entities/PermissionDeniedException.java
+++ b/rx_paparazzo/src/main/java/com/fuck_boilerplate/rx_paparazzo/entities/PermissionDeniedException.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2016 FuckBoilerplate
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.fuck_boilerplate.rx_paparazzo.entities;
+
+public class PermissionDeniedException extends RuntimeException {
+}

--- a/rx_paparazzo/src/main/java/com/fuck_boilerplate/rx_paparazzo/interactors/GrantPermissions.java
+++ b/rx_paparazzo/src/main/java/com/fuck_boilerplate/rx_paparazzo/interactors/GrantPermissions.java
@@ -18,6 +18,7 @@ package com.fuck_boilerplate.rx_paparazzo.interactors;
 
 import android.Manifest;
 
+import com.fuck_boilerplate.rx_paparazzo.entities.PermissionDeniedException;
 import com.fuck_boilerplate.rx_paparazzo.entities.TargetUi;
 import com.fuck_boilerplate.rx_paparazzo.entities.UserCanceledException;
 import com.tbruyelle.rxpermissions.RxPermissions;
@@ -38,7 +39,7 @@ public final class GrantPermissions extends UseCase<Void> {
         return permissions.request(Manifest.permission.WRITE_EXTERNAL_STORAGE, Manifest.permission.READ_EXTERNAL_STORAGE)
                  .flatMap(granted -> {
                      if (granted) return Observable.<Void>just(null);
-                     throw new UserCanceledException();
+                     throw new PermissionDeniedException();
                  });
     }
 }


### PR DESCRIPTION
Right now, if the user denies a permission, the outcome is the same as if the user presses back in the camera activity. This change is to avoid this.