### PR TITLE
Remove dependency on Dagger 2 and Retrolambda

### DIFF
--- a/rx_paparazzo/build.gradle
+++ b/rx_paparazzo/build.gradle
@@ -1,7 +1,5 @@
 apply plugin: 'com.android.library'
 apply plugin: 'com.github.dcendents.android-maven'
-apply plugin: 'me.tatarka.retrolambda'
-apply plugin: 'android-apt'
 
 group='com.github.FuckBoilerplate'
 
@@ -12,8 +10,6 @@ buildscript {
     }
 
     dependencies {
-        classpath 'me.tatarka:gradle-retrolambda:3.2.4'
-        classpath "com.neenbedankt.gradle.plugins:android-apt:1.8"
     }
 }
 
@@ -33,10 +29,6 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
     lintOptions {
         abortOnError false
     }
@@ -50,10 +42,6 @@ dependencies {
     compile 'com.github.VictorAlbertos:RxActivityResult:0.3.3'
     compile 'com.tbruyelle.rxpermissions:rxpermissions:0.5.2@aar'
     compile 'com.yalantis:ucrop:1.3.2'
-
-    apt "com.google.dagger:dagger-compiler:2.0.2"
-    compile "com.google.dagger:dagger:2.0.2"
-    compile "org.glassfish:javax.annotation:10.0-b28"
 
     testCompile 'junit:junit:4.12'
 }

--- a/rx_paparazzo/src/main/java/com/fuck_boilerplate/rx_paparazzo/RxPaparazzo.java
+++ b/rx_paparazzo/src/main/java/com/fuck_boilerplate/rx_paparazzo/RxPaparazzo.java
@@ -25,7 +25,6 @@ import com.fuck_boilerplate.rx_paparazzo.entities.Response;
 import com.fuck_boilerplate.rx_paparazzo.entities.Size;
 import com.fuck_boilerplate.rx_paparazzo.internal.di.ApplicationComponent;
 import com.fuck_boilerplate.rx_paparazzo.internal.di.ApplicationModule;
-import com.fuck_boilerplate.rx_paparazzo.internal.di.DaggerApplicationComponent;
 import com.yalantis.ucrop.UCrop;
 
 import java.util.List;
@@ -68,9 +67,7 @@ public final class RxPaparazzo {
 
         public Builder(T ui) {
             this.config = new Config();
-            this.applicationComponent = DaggerApplicationComponent.builder()
-                    .applicationModule(new ApplicationModule(config, ui))
-                    .build();
+            this.applicationComponent = ApplicationComponent.create(new ApplicationModule(config, ui));
         }
     }
 

--- a/rx_paparazzo/src/main/java/com/fuck_boilerplate/rx_paparazzo/entities/TargetUi.java
+++ b/rx_paparazzo/src/main/java/com/fuck_boilerplate/rx_paparazzo/entities/TargetUi.java
@@ -33,7 +33,9 @@ public class TargetUi {
     }
 
     @Nullable public Fragment fragment() {
-        if (ui instanceof Fragment) return (Fragment) ui;
+        if (ui instanceof Fragment) {
+            return (Fragment) ui;
+        }
         return null;
     }
 

--- a/rx_paparazzo/src/main/java/com/fuck_boilerplate/rx_paparazzo/interactors/GetDimens.java
+++ b/rx_paparazzo/src/main/java/com/fuck_boilerplate/rx_paparazzo/interactors/GetDimens.java
@@ -49,10 +49,12 @@ public final class GetDimens extends UseCase<int[]> {
                 .map(new Func1<String, int[]>() {
                     @Override
                     public int[] call(String filePath) {
-                        if (config.getSize() == Size.Original)
+                        if (config.getSize() == Size.Original) {
                             return GetDimens.this.getFileDimens(filePath);
-                        else if (config.getSize() == Size.Screen)
+                        }
+                        else if (config.getSize() == Size.Screen) {
                             return GetDimens.this.getScreenDimens();
+                        }
                         else {
                             int[] dimens = GetDimens.this.getScreenDimens();
                             return new int[]{dimens[0] / 8, dimens[1] / 8};

--- a/rx_paparazzo/src/main/java/com/fuck_boilerplate/rx_paparazzo/interactors/GetDimens.java
+++ b/rx_paparazzo/src/main/java/com/fuck_boilerplate/rx_paparazzo/interactors/GetDimens.java
@@ -24,9 +24,8 @@ import com.fuck_boilerplate.rx_paparazzo.entities.Config;
 import com.fuck_boilerplate.rx_paparazzo.entities.Size;
 import com.fuck_boilerplate.rx_paparazzo.entities.TargetUi;
 
-import javax.inject.Inject;
-
 import rx.Observable;
+import rx.functions.Func1;
 
 public final class GetDimens extends UseCase<int[]> {
     private final TargetUi targetUi;
@@ -34,7 +33,7 @@ public final class GetDimens extends UseCase<int[]> {
     private final GetPath getPath;
     private Uri uri;
 
-    @Inject public GetDimens(TargetUi targetUi, Config config, GetPath getPath) {
+     public GetDimens(TargetUi targetUi, Config config, GetPath getPath) {
         this.targetUi = targetUi;
         this.config = config;
         this.getPath = getPath;
@@ -47,14 +46,17 @@ public final class GetDimens extends UseCase<int[]> {
 
     @Override public Observable<int[]> react() {
         return getPath.with(uri).react()
-                .map(filePath -> {
-                    if (config.getSize() == Size.Original)
-                        return getFileDimens(filePath);
-                    else if (config.getSize() == Size.Screen)
-                        return getScreenDimens();
-                    else {
-                        int[] dimens = getScreenDimens();
-                        return new int[]{dimens[0] / 8, dimens[1] / 8};
+                .map(new Func1<String, int[]>() {
+                    @Override
+                    public int[] call(String filePath) {
+                        if (config.getSize() == Size.Original)
+                            return GetDimens.this.getFileDimens(filePath);
+                        else if (config.getSize() == Size.Screen)
+                            return GetDimens.this.getScreenDimens();
+                        else {
+                            int[] dimens = GetDimens.this.getScreenDimens();
+                            return new int[]{dimens[0] / 8, dimens[1] / 8};
+                        }
                     }
                 });
     }

--- a/rx_paparazzo/src/main/java/com/fuck_boilerplate/rx_paparazzo/interactors/GetPath.java
+++ b/rx_paparazzo/src/main/java/com/fuck_boilerplate/rx_paparazzo/interactors/GetPath.java
@@ -28,8 +28,6 @@ import android.provider.MediaStore;
 
 import com.fuck_boilerplate.rx_paparazzo.entities.TargetUi;
 
-import javax.inject.Inject;
-
 import rx.Observable;
 import rx.exceptions.Exceptions;
 
@@ -37,7 +35,7 @@ public final class GetPath extends UseCase<String> {
     private final TargetUi targetUi;
     private Uri uri;
 
-    @Inject public GetPath(TargetUi targetUi) {
+     public GetPath(TargetUi targetUi) {
         this.targetUi = targetUi;
     }
 
@@ -55,12 +53,16 @@ public final class GetPath extends UseCase<String> {
         boolean isKitKat = Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT;
         Context context = targetUi.activity();
 
-        if (uri == null) return null;
+        if (uri == null) {
+            return null;
+        }
 
         if (isKitKat && DocumentsContract.isDocumentUri(context, uri)) {
             if (isExternalStorageDocument(uri)) {
                 Document document = getDocument(uri);
-                if ("primary".equalsIgnoreCase(document.type)) return Environment.getExternalStorageDirectory() + "/" + document.id;
+                if ("primary".equalsIgnoreCase(document.type)) {
+                    return Environment.getExternalStorageDirectory() + "/" + document.id;
+                }
                 return null;
             } else if (isDownloadsDocument(uri)) {
                 String id = DocumentsContract.getDocumentId(uri);
@@ -69,15 +71,25 @@ public final class GetPath extends UseCase<String> {
             } else if (isMediaDocument(uri)) {
                 Document document = getDocument(uri);
                 Uri contentUri = null;
-                if ("image".equals(document.type)) contentUri = MediaStore.Images.Media.EXTERNAL_CONTENT_URI;
-                else if ("video".equals(document.type)) contentUri = MediaStore.Video.Media.EXTERNAL_CONTENT_URI;
-                else if ("audio".equals(document.type)) contentUri = MediaStore.Audio.Media.EXTERNAL_CONTENT_URI;
+                if ("image".equals(document.type)) {
+                    contentUri = MediaStore.Images.Media.EXTERNAL_CONTENT_URI;
+                }
+                else if ("video".equals(document.type)) {
+                    contentUri = MediaStore.Video.Media.EXTERNAL_CONTENT_URI;
+                }
+                else if ("audio".equals(document.type)) {
+                    contentUri = MediaStore.Audio.Media.EXTERNAL_CONTENT_URI;
+                }
 
                 return getDataColumn(context, contentUri, "_id=?", new String[] {document.id});
             }
         }
-        else if ("content".equalsIgnoreCase(uri.getScheme())) return getDataColumn(context, uri, null, null);
-        else if ("file".equalsIgnoreCase(uri.getScheme())) return uri.getPath();
+        else if ("content".equalsIgnoreCase(uri.getScheme())) {
+            return getDataColumn(context, uri, null, null);
+        }
+        else if ("file".equalsIgnoreCase(uri.getScheme())) {
+            return uri.getPath();
+        }
 
         return null;
     }
@@ -109,7 +121,9 @@ public final class GetPath extends UseCase<String> {
         } catch (Exception e) {
             throw Exceptions.propagate(e);
         } finally {
-            if (cursor != null) cursor.close();
+            if (cursor != null) {
+                cursor.close();
+            }
         }
     }
 

--- a/rx_paparazzo/src/main/java/com/fuck_boilerplate/rx_paparazzo/interactors/GrantPermissions.java
+++ b/rx_paparazzo/src/main/java/com/fuck_boilerplate/rx_paparazzo/interactors/GrantPermissions.java
@@ -20,15 +20,14 @@ import com.fuck_boilerplate.rx_paparazzo.entities.PermissionDeniedException;
 import com.fuck_boilerplate.rx_paparazzo.entities.TargetUi;
 import com.tbruyelle.rxpermissions.RxPermissions;
 
-import javax.inject.Inject;
-
 import rx.Observable;
+import rx.functions.Func1;
 
 public final class GrantPermissions extends UseCase<Void> {
     private final TargetUi targetUi;
     private String[] permissions;
 
-    @Inject public GrantPermissions(TargetUi targetUi) {
+     public GrantPermissions(TargetUi targetUi) {
         this.targetUi = targetUi;
     }
 
@@ -40,9 +39,15 @@ public final class GrantPermissions extends UseCase<Void> {
     @Override public Observable<Void> react() {
         return RxPermissions.getInstance(targetUi.activity())
                 .request(permissions)
-                .flatMap(granted -> {
-                    if (granted) return Observable.<Void>just(null);
-                    throw new PermissionDeniedException();
+                .flatMap(new Func1<Boolean, Observable<Void>>() {
+                    @Override
+                    public Observable<Void> call(Boolean granted) {
+                        if (granted) {
+                            return Observable.just(null);
+                        }
+                        // FIXME Observable.error() to respect the Observable contract
+                        throw new PermissionDeniedException();
+                    }
                 });
     }
 }

--- a/rx_paparazzo/src/main/java/com/fuck_boilerplate/rx_paparazzo/interactors/PickImage.java
+++ b/rx_paparazzo/src/main/java/com/fuck_boilerplate/rx_paparazzo/interactors/PickImage.java
@@ -22,22 +22,26 @@ import android.os.Build;
 
 import com.fuck_boilerplate.rx_paparazzo.entities.TargetUi;
 
-import javax.inject.Inject;
-
 import rx.Observable;
+import rx.functions.Func1;
 
 public final class PickImage extends UseCase<Uri> {
     private final StartIntent startIntent;
     private final TargetUi targetUi;
 
-    @Inject public PickImage(StartIntent startIntent, TargetUi targetUi) {
+     public PickImage(StartIntent startIntent, TargetUi targetUi) {
         this.startIntent = startIntent;
         this.targetUi = targetUi;
     }
 
     @Override public Observable<Uri> react() {
         return startIntent.with(getFileChooserIntent()).react()
-                .map(intent -> intent.getData());
+                .map(new Func1<Intent, Uri>() {
+                    @Override
+                    public Uri call(Intent intent) {
+                        return intent.getData();
+                    }
+                });
     }
 
     private Intent getFileChooserIntent() {

--- a/rx_paparazzo/src/main/java/com/fuck_boilerplate/rx_paparazzo/interactors/PickImages.java
+++ b/rx_paparazzo/src/main/java/com/fuck_boilerplate/rx_paparazzo/interactors/PickImages.java
@@ -74,8 +74,9 @@ public final class PickImages extends UseCase<List<Uri>>{
             intent.addCategory(Intent.CATEGORY_OPENABLE);
         }
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
             intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true);
+        }
 
         return intent;
     }

--- a/rx_paparazzo/src/main/java/com/fuck_boilerplate/rx_paparazzo/interactors/PickImages.java
+++ b/rx_paparazzo/src/main/java/com/fuck_boilerplate/rx_paparazzo/interactors/PickImages.java
@@ -25,22 +25,26 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import javax.inject.Inject;
-
 import rx.Observable;
+import rx.functions.Func1;
 
 public final class PickImages extends UseCase<List<Uri>>{
     private final StartIntent startIntent;
 
-    @Inject public PickImages(StartIntent startIntent) {
+     public PickImages(StartIntent startIntent) {
         this.startIntent = startIntent;
     }
 
     @Override public Observable<List<Uri>> react() {
         return startIntent.with(getFileChooserIntent()).react()
-                .map(intent -> {
-                    if (intent.getData() != null) return Arrays.asList(intent.getData());
-                    else return getUris(intent);
+                .map(new Func1<Intent, List<Uri>>() {
+                    @Override
+                    public List<Uri> call(Intent intent) {
+                        if (intent.getData() != null) {
+                            return Arrays.asList(intent.getData());
+                        }
+                        else return PickImages.this.getUris(intent);
+                    }
                 });
     }
 

--- a/rx_paparazzo/src/main/java/com/fuck_boilerplate/rx_paparazzo/interactors/SaveImage.java
+++ b/rx_paparazzo/src/main/java/com/fuck_boilerplate/rx_paparazzo/interactors/SaveImage.java
@@ -46,8 +46,8 @@ import rx.functions.Func1;
 import rx.functions.Func3;
 
 public final class SaveImage extends UseCase<String> {
-    public static final String DATE_FORMAT = "ddMMyyyy_HHmmss";
-    public static final String LOCALE_EN = "en";
+    private static final String DATE_FORMAT = "ddMMyyyy_HHmmss";
+    private static final String LOCALE_EN = "en";
     private final TargetUi targetUi;
     private final Config config;
     private final GetPath getPath;
@@ -71,17 +71,25 @@ public final class SaveImage extends UseCase<String> {
                 .flatMap(new Func1<Uri, Observable<String>>() {
                     @Override
                     public Observable<String> call(Uri outputUri) {
-                        return Observable.zip(getPath.with(uri).react(), getPath.with(outputUri).react(), getDimens.with(uri).react(),
+                        return Observable.zip(getPath.with(uri).react(),
+                                getPath.with(outputUri).react(), getDimens.with(uri).react(),
                                 new Func3<String, String, int[], String>() {
                                     @Override
-                                    public String call(String filePath, String filePathOutput, int[] dimens) {
-                                        String filepath = SaveImage.this.scaleImage(filePath, filePathOutput, dimens);
-                                        MediaScannerConnection.scanFile(targetUi.getContext(), new String[]{filepath}, new String[]{"image/jpeg"}, null);
+                                    public String call(String filePath, String filePathOutput,
+                                            int[] dimens) {
+                                        String filepath = SaveImage.this.scaleImage(filePath,
+                                                filePathOutput, dimens);
+                                        MediaScannerConnection.scanFile(targetUi.getContext(),
+                                                new String[] {
+                                                        filepath
+                                        }, new String[] {
+                                                "image/jpeg"
+                                        }, null);
                                         return filepath;
                                     }
                                 });
                     }
-                });
+        });
     }
 
     private Observable<Uri> getOutputUri() {

--- a/rx_paparazzo/src/main/java/com/fuck_boilerplate/rx_paparazzo/interactors/TakePhoto.java
+++ b/rx_paparazzo/src/main/java/com/fuck_boilerplate/rx_paparazzo/interactors/TakePhoto.java
@@ -28,6 +28,7 @@ import rx.Observable;
 import rx.functions.Func1;
 
 public final class TakePhoto extends UseCase<Uri> {
+    private static final String SHOOT_APPEND = "shoot.jpg";
     private final StartIntent startIntent;
     private final TargetUi targetUi;
 
@@ -52,7 +53,7 @@ public final class TakePhoto extends UseCase<Uri> {
 
         return Uri.fromFile(file)
                 .buildUpon()
-                .appendPath("shoot.jpg")
+                .appendPath(SHOOT_APPEND)
                 .build();
     }
 

--- a/rx_paparazzo/src/main/java/com/fuck_boilerplate/rx_paparazzo/interactors/TakePhoto.java
+++ b/rx_paparazzo/src/main/java/com/fuck_boilerplate/rx_paparazzo/interactors/TakePhoto.java
@@ -24,23 +24,27 @@ import com.fuck_boilerplate.rx_paparazzo.entities.TargetUi;
 
 import java.io.File;
 
-import javax.inject.Inject;
-
 import rx.Observable;
+import rx.functions.Func1;
 
 public final class TakePhoto extends UseCase<Uri> {
     private final StartIntent startIntent;
     private final TargetUi targetUi;
 
-    @Inject  public TakePhoto(StartIntent startIntent, TargetUi targetUi) {
+      public TakePhoto(StartIntent startIntent, TargetUi targetUi) {
         this.startIntent = startIntent;
         this.targetUi = targetUi;
     }
 
     @Override public Observable<Uri> react() {
-        Uri uri = getUri();
+        final Uri uri = getUri();
         return startIntent.with(getIntentCamera(uri)).react()
-                .map(data -> uri);
+                .map(new Func1<Intent, Uri>() {
+                    @Override
+                    public Uri call(Intent data) {
+                        return uri;
+                    }
+                });
     }
 
     private Uri getUri() {

--- a/rx_paparazzo/src/main/java/com/fuck_boilerplate/rx_paparazzo/internal/di/ApplicationComponent.java
+++ b/rx_paparazzo/src/main/java/com/fuck_boilerplate/rx_paparazzo/internal/di/ApplicationComponent.java
@@ -20,14 +20,33 @@ import com.fuck_boilerplate.rx_paparazzo.interactors.GetPath;
 import com.fuck_boilerplate.rx_paparazzo.workers.Camera;
 import com.fuck_boilerplate.rx_paparazzo.workers.Gallery;
 
-import javax.inject.Singleton;
+public abstract class ApplicationComponent {
+    public abstract Camera camera();
 
-import dagger.Component;
+    public abstract Gallery gallery();
 
-@Component(modules = ApplicationModule.class)
-@Singleton
-public interface ApplicationComponent {
-    Camera camera();
-    Gallery gallery();
-    GetPath getPath();
+    public abstract GetPath getPath();
+
+    public static ApplicationComponent create(final ApplicationModule applicationModule) {
+        return new ApplicationComponent() {
+            @Override
+            public Camera camera() {
+                return new Camera(applicationModule.takePhoto, applicationModule.cropImage,
+                        applicationModule.saveImage, applicationModule.grantPermissions,
+                        applicationModule.ui);
+            }
+
+            @Override
+            public Gallery gallery() {
+                return new Gallery(applicationModule.grantPermissions, applicationModule.pickImages,
+                        applicationModule.pickImage, applicationModule.cropImage,
+                        applicationModule.saveImage, applicationModule.ui);
+            }
+
+            @Override
+            public GetPath getPath() {
+                return new GetPath(applicationModule.ui);
+            }
+        };
+    }
 }

--- a/rx_paparazzo/src/main/java/com/fuck_boilerplate/rx_paparazzo/internal/di/ApplicationComponent.java
+++ b/rx_paparazzo/src/main/java/com/fuck_boilerplate/rx_paparazzo/internal/di/ApplicationComponent.java
@@ -28,21 +28,6 @@ public abstract class ApplicationComponent {
     public abstract GetPath getPath();
 
     public static ApplicationComponent create(final ApplicationModule applicationModule) {
-        return new ApplicationComponent() {
-            @Override
-            public Camera camera() {
-                return applicationModule.camera;
-            }
-
-            @Override
-            public Gallery gallery() {
-                return applicationModule.gallery;
-            }
-
-            @Override
-            public GetPath getPath() {
-                return applicationModule.getPath;
-            }
-        };
+        return new ApplicationComponentImpl(applicationModule.getUi(), applicationModule.getConfig());
     }
 }

--- a/rx_paparazzo/src/main/java/com/fuck_boilerplate/rx_paparazzo/internal/di/ApplicationComponent.java
+++ b/rx_paparazzo/src/main/java/com/fuck_boilerplate/rx_paparazzo/internal/di/ApplicationComponent.java
@@ -31,21 +31,17 @@ public abstract class ApplicationComponent {
         return new ApplicationComponent() {
             @Override
             public Camera camera() {
-                return new Camera(applicationModule.takePhoto, applicationModule.cropImage,
-                        applicationModule.saveImage, applicationModule.grantPermissions,
-                        applicationModule.ui);
+                return applicationModule.camera;
             }
 
             @Override
             public Gallery gallery() {
-                return new Gallery(applicationModule.grantPermissions, applicationModule.pickImages,
-                        applicationModule.pickImage, applicationModule.cropImage,
-                        applicationModule.saveImage, applicationModule.ui);
+                return applicationModule.gallery;
             }
 
             @Override
             public GetPath getPath() {
-                return new GetPath(applicationModule.ui);
+                return applicationModule.getPath;
             }
         };
     }

--- a/rx_paparazzo/src/main/java/com/fuck_boilerplate/rx_paparazzo/internal/di/ApplicationComponentImpl.java
+++ b/rx_paparazzo/src/main/java/com/fuck_boilerplate/rx_paparazzo/internal/di/ApplicationComponentImpl.java
@@ -1,0 +1,59 @@
+
+package com.fuck_boilerplate.rx_paparazzo.internal.di;
+
+import com.fuck_boilerplate.rx_paparazzo.entities.Config;
+import com.fuck_boilerplate.rx_paparazzo.entities.TargetUi;
+import com.fuck_boilerplate.rx_paparazzo.interactors.CropImage;
+import com.fuck_boilerplate.rx_paparazzo.interactors.GetDimens;
+import com.fuck_boilerplate.rx_paparazzo.interactors.GetPath;
+import com.fuck_boilerplate.rx_paparazzo.interactors.GrantPermissions;
+import com.fuck_boilerplate.rx_paparazzo.interactors.PickImage;
+import com.fuck_boilerplate.rx_paparazzo.interactors.PickImages;
+import com.fuck_boilerplate.rx_paparazzo.interactors.SaveImage;
+import com.fuck_boilerplate.rx_paparazzo.interactors.StartIntent;
+import com.fuck_boilerplate.rx_paparazzo.interactors.TakePhoto;
+import com.fuck_boilerplate.rx_paparazzo.workers.Camera;
+import com.fuck_boilerplate.rx_paparazzo.workers.Gallery;
+
+class ApplicationComponentImpl extends ApplicationComponent {
+    private final StartIntent startIntent;
+    private final GetPath getPath;
+    private final GetDimens getDimens;
+    private final TakePhoto takePhoto;
+    private final CropImage cropImage;
+    private final SaveImage saveImage;
+    private final GrantPermissions grantPermissions;
+    private final PickImages pickImages;
+    private final PickImage pickImage;
+    private final Camera camera;
+    private final Gallery gallery;
+
+    public ApplicationComponentImpl(TargetUi ui, Config config) {
+        startIntent = new StartIntent(ui);
+        getPath = new GetPath(ui);
+        takePhoto = new TakePhoto(startIntent, ui);
+        getDimens = new GetDimens(ui, config, getPath);
+        cropImage = new CropImage(ui, config, startIntent, getPath, getDimens);
+        saveImage = new SaveImage(ui, config, getPath, getDimens);
+        grantPermissions = new GrantPermissions(ui);
+        pickImages = new PickImages(startIntent);
+        pickImage = new PickImage(startIntent, ui);
+        camera = new Camera(takePhoto, cropImage, saveImage, grantPermissions, ui);
+        gallery = new Gallery(grantPermissions, pickImages, pickImage, cropImage, saveImage, ui);
+    }
+
+    @Override
+    public Camera camera() {
+        return camera;
+    }
+
+    @Override
+    public Gallery gallery() {
+        return gallery;
+    }
+
+    @Override
+    public GetPath getPath() {
+        return getPath;
+    }
+}

--- a/rx_paparazzo/src/main/java/com/fuck_boilerplate/rx_paparazzo/internal/di/ApplicationModule.java
+++ b/rx_paparazzo/src/main/java/com/fuck_boilerplate/rx_paparazzo/internal/di/ApplicationModule.java
@@ -18,24 +18,40 @@ package com.fuck_boilerplate.rx_paparazzo.internal.di;
 
 import com.fuck_boilerplate.rx_paparazzo.entities.Config;
 import com.fuck_boilerplate.rx_paparazzo.entities.TargetUi;
+import com.fuck_boilerplate.rx_paparazzo.interactors.CropImage;
+import com.fuck_boilerplate.rx_paparazzo.interactors.GetDimens;
+import com.fuck_boilerplate.rx_paparazzo.interactors.GetPath;
+import com.fuck_boilerplate.rx_paparazzo.interactors.GrantPermissions;
+import com.fuck_boilerplate.rx_paparazzo.interactors.PickImage;
+import com.fuck_boilerplate.rx_paparazzo.interactors.PickImages;
+import com.fuck_boilerplate.rx_paparazzo.interactors.SaveImage;
+import com.fuck_boilerplate.rx_paparazzo.interactors.StartIntent;
+import com.fuck_boilerplate.rx_paparazzo.interactors.TakePhoto;
 
-import dagger.Module;
-import dagger.Provides;
+public class ApplicationModule {
+    final Config config;
+    final TargetUi ui;
+    final StartIntent startIntent;
+    final GetPath getPath;
+    final GetDimens getDimens;
+    final TakePhoto takePhoto;
+    final CropImage cropImage;
+    final SaveImage saveImage;
+    final GrantPermissions grantPermissions;
+    final PickImages pickImages;
+    final PickImage pickImage;
 
-@Module public class ApplicationModule {
-    private final Config config;
-    private final TargetUi ui;
-
-    public ApplicationModule(Config config, Object ui) {
+    public ApplicationModule(Config config, Object originUi) {
         this.config = config;
-        this.ui = new TargetUi(ui);
-    }
-
-    @Provides Config provideConfig() {
-        return config;
-    }
-
-    @Provides TargetUi provideTargetUi() {
-        return ui;
+        ui = new TargetUi(originUi);
+        startIntent = new StartIntent(this.ui);
+        getPath = new GetPath(ui);
+        takePhoto = new TakePhoto(startIntent, this.ui);
+        getDimens = new GetDimens(ui, config, getPath);
+        cropImage = new CropImage(ui, config, startIntent, getPath, getDimens);
+        saveImage = new SaveImage(ui, config, getPath, getDimens);
+        grantPermissions = new GrantPermissions(ui);
+        pickImages = new PickImages(startIntent);
+        pickImage = new PickImage(startIntent, ui);
     }
 }

--- a/rx_paparazzo/src/main/java/com/fuck_boilerplate/rx_paparazzo/internal/di/ApplicationModule.java
+++ b/rx_paparazzo/src/main/java/com/fuck_boilerplate/rx_paparazzo/internal/di/ApplicationModule.java
@@ -18,46 +18,21 @@ package com.fuck_boilerplate.rx_paparazzo.internal.di;
 
 import com.fuck_boilerplate.rx_paparazzo.entities.Config;
 import com.fuck_boilerplate.rx_paparazzo.entities.TargetUi;
-import com.fuck_boilerplate.rx_paparazzo.interactors.CropImage;
-import com.fuck_boilerplate.rx_paparazzo.interactors.GetDimens;
-import com.fuck_boilerplate.rx_paparazzo.interactors.GetPath;
-import com.fuck_boilerplate.rx_paparazzo.interactors.GrantPermissions;
-import com.fuck_boilerplate.rx_paparazzo.interactors.PickImage;
-import com.fuck_boilerplate.rx_paparazzo.interactors.PickImages;
-import com.fuck_boilerplate.rx_paparazzo.interactors.SaveImage;
-import com.fuck_boilerplate.rx_paparazzo.interactors.StartIntent;
-import com.fuck_boilerplate.rx_paparazzo.interactors.TakePhoto;
-import com.fuck_boilerplate.rx_paparazzo.workers.Camera;
-import com.fuck_boilerplate.rx_paparazzo.workers.Gallery;
 
 public class ApplicationModule {
-    final Config config;
-    final TargetUi ui;
-    final StartIntent startIntent;
-    final GetPath getPath;
-    final GetDimens getDimens;
-    final TakePhoto takePhoto;
-    final CropImage cropImage;
-    final SaveImage saveImage;
-    final GrantPermissions grantPermissions;
-    final PickImages pickImages;
-    final PickImage pickImage;
-    final Camera camera;
-    final Gallery gallery;
+    private final Config config;
+    private final TargetUi ui;
 
     public ApplicationModule(Config config, Object originUi) {
         this.config = config;
         ui = new TargetUi(originUi);
-        startIntent = new StartIntent(this.ui);
-        getPath = new GetPath(ui);
-        takePhoto = new TakePhoto(startIntent, this.ui);
-        getDimens = new GetDimens(ui, config, getPath);
-        cropImage = new CropImage(ui, config, startIntent, getPath, getDimens);
-        saveImage = new SaveImage(ui, config, getPath, getDimens);
-        grantPermissions = new GrantPermissions(ui);
-        pickImages = new PickImages(startIntent);
-        pickImage = new PickImage(startIntent, ui);
-        camera = new Camera(takePhoto, cropImage, saveImage, grantPermissions, ui);
-        gallery = new Gallery(grantPermissions, pickImages, pickImage, cropImage, saveImage, ui);
+    }
+
+    public Config getConfig() {
+        return config;
+    }
+
+    public TargetUi getUi() {
+        return ui;
     }
 }

--- a/rx_paparazzo/src/main/java/com/fuck_boilerplate/rx_paparazzo/internal/di/ApplicationModule.java
+++ b/rx_paparazzo/src/main/java/com/fuck_boilerplate/rx_paparazzo/internal/di/ApplicationModule.java
@@ -27,6 +27,8 @@ import com.fuck_boilerplate.rx_paparazzo.interactors.PickImages;
 import com.fuck_boilerplate.rx_paparazzo.interactors.SaveImage;
 import com.fuck_boilerplate.rx_paparazzo.interactors.StartIntent;
 import com.fuck_boilerplate.rx_paparazzo.interactors.TakePhoto;
+import com.fuck_boilerplate.rx_paparazzo.workers.Camera;
+import com.fuck_boilerplate.rx_paparazzo.workers.Gallery;
 
 public class ApplicationModule {
     final Config config;
@@ -40,6 +42,8 @@ public class ApplicationModule {
     final GrantPermissions grantPermissions;
     final PickImages pickImages;
     final PickImage pickImage;
+    final Camera camera;
+    final Gallery gallery;
 
     public ApplicationModule(Config config, Object originUi) {
         this.config = config;
@@ -53,5 +57,7 @@ public class ApplicationModule {
         grantPermissions = new GrantPermissions(ui);
         pickImages = new PickImages(startIntent);
         pickImage = new PickImage(startIntent, ui);
+        camera = new Camera(takePhoto, cropImage, saveImage, grantPermissions, ui);
+        gallery = new Gallery(grantPermissions, pickImages, pickImage, cropImage, saveImage, ui);
     }
 }


### PR DESCRIPTION
It makes the project compatible with applications that can't support dagger 2, apt, and retrolambda.

- Dependency Injection via Dagger 2 has been replaced by naïve manual injection.
- Retrolambda has been replaced by anonymous classes with checked typing.
- Some stylistic changes based off SonarLint checks.