### PR TITLE
Solves #23 - READ_EXTERNAL_STORAGE permission missing when using .use…

### DIFF
--- a/rx_paparazzo/src/main/java/com/fuck_boilerplate/rx_paparazzo/workers/Gallery.java
+++ b/rx_paparazzo/src/main/java/com/fuck_boilerplate/rx_paparazzo/workers/Gallery.java
@@ -121,7 +121,7 @@ public final class Gallery extends Worker {
 
     private String[] permissions() {
         if (config.useInternalStorage()) {
-            return new String[] {};
+            return new String[] {Manifest.permission.READ_EXTERNAL_STORAGE};
         } else {
             return new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE, Manifest.permission.READ_EXTERNAL_STORAGE};
         }


### PR DESCRIPTION
Solves #23 - READ_EXTERNAL_STORAGE permission missing when using .useInternalStorage() with .usingGallery()